### PR TITLE
Refine main dashboard layout and styling

### DIFF
--- a/Main.Designer.cs
+++ b/Main.Designer.cs
@@ -5,21 +5,19 @@
         private System.ComponentModel.IContainer components = null;
 
         private System.Windows.Forms.Label lblTitle;
+        private Windows10.Components.GradientPanel panelHeader;
+        private System.Windows.Forms.Label lblSubtitle;
         private System.Windows.Forms.Panel panelStats;
+        private System.Windows.Forms.Label lblStatsTitle;
         private System.Windows.Forms.Label lblStats;
         private System.Windows.Forms.Timer systemInfoTimer;
-
-        // Declare buttons only – all setup handled in Main.cs
-        private System.Windows.Forms.Button btnRemoveOneDrive;
-        private System.Windows.Forms.Button btnRemoveTelemetry;
-        private System.Windows.Forms.Button btnDisableDefenderCloud;
-        private System.Windows.Forms.Button btnDisableCortana;
-        private System.Windows.Forms.Button btnDisableAdID;
-        private System.Windows.Forms.Button btnBlockMicrosoftIPs;
-        private System.Windows.Forms.Button btnDisableFeedback;
-        private System.Windows.Forms.Button btnRemoveXbox;
-        private System.Windows.Forms.Button btnDisableUpdates;
-        private System.Windows.Forms.Button btnRemoveSuggestions;
+        private System.Windows.Forms.TableLayoutPanel layoutMain;
+        private System.Windows.Forms.Panel panelButtons;
+        private System.Windows.Forms.Label lblActionsTitle;
+        private System.Windows.Forms.FlowLayoutPanel flowButtons;
+        private System.Windows.Forms.Panel panelLogger;
+        private System.Windows.Forms.Label lblLoggerTitle;
+        private System.Windows.Forms.Panel panelRunAll;
 
         protected override void Dispose(bool disposing)
         {
@@ -34,145 +32,221 @@
         {
             components = new System.ComponentModel.Container();
             lblTitle = new Label();
+            panelHeader = new Windows10.Components.GradientPanel();
+            lblSubtitle = new Label();
             panelStats = new Panel();
             lblStats = new Label();
             systemInfoTimer = new System.Windows.Forms.Timer(components);
-            btnRemoveOneDrive = new Button();
-            btnRemoveTelemetry = new Button();
-            btnDisableDefenderCloud = new Button();
-            btnDisableCortana = new Button();
-            btnDisableAdID = new Button();
-            btnBlockMicrosoftIPs = new Button();
-            btnDisableFeedback = new Button();
-            btnRemoveXbox = new Button();
-            btnDisableUpdates = new Button();
-            btnRemoveSuggestions = new Button();
+            layoutMain = new TableLayoutPanel();
+            panelButtons = new Panel();
+            flowButtons = new FlowLayoutPanel();
+            panelRunAll = new Panel();
+            lblActionsTitle = new Label();
+            panelLogger = new Panel();
+            lblLoggerTitle = new Label();
+            lblStatsTitle = new Label();
+            panelHeader.SuspendLayout();
             panelStats.SuspendLayout();
+            layoutMain.SuspendLayout();
+            panelButtons.SuspendLayout();
+            panelLogger.SuspendLayout();
             SuspendLayout();
-            // 
+            //
+            // panelHeader
+            //
+            panelHeader.Angle = 90F;
+            panelHeader.Controls.Add(lblSubtitle);
+            panelHeader.Controls.Add(lblTitle);
+            panelHeader.Dock = DockStyle.Top;
+            panelHeader.EndColor = Color.FromArgb(27, 32, 60);
+            panelHeader.Location = new Point(0, 0);
+            panelHeader.Name = "panelHeader";
+            panelHeader.Padding = new Padding(30, 18, 30, 18);
+            panelHeader.Size = new Size(920, 110);
+            panelHeader.StartColor = Color.FromArgb(58, 123, 213);
+            panelHeader.TabIndex = 0;
+            //
+            // lblSubtitle
+            //
+            lblSubtitle.AutoSize = true;
+            lblSubtitle.Font = new Font("Segoe UI", 10F);
+            lblSubtitle.ForeColor = Color.FromArgb(210, 218, 235);
+            lblSubtitle.Location = new Point(33, 68);
+            lblSubtitle.Name = "lblSubtitle";
+            lblSubtitle.Size = new Size(331, 19);
+            lblSubtitle.TabIndex = 2;
+            lblSubtitle.Text = "Streamline Windows 10 for performance, privacy, and ease.";
+            //
             // lblTitle
-            // 
+            //
             lblTitle.AutoSize = true;
-            lblTitle.Font = new Font("Segoe UI", 16F, FontStyle.Bold);
+            lblTitle.Font = new Font("Segoe UI", 20F, FontStyle.Bold);
             lblTitle.ForeColor = Color.White;
-            lblTitle.Location = new Point(300, 20);
+            lblTitle.Location = new Point(30, 20);
             lblTitle.Name = "lblTitle";
-            lblTitle.Size = new Size(287, 30);
-            lblTitle.TabIndex = 0;
-            lblTitle.Text = "\U0001fa79 Win10 Debloater By Literal";
+            lblTitle.Size = new Size(336, 37);
+            lblTitle.TabIndex = 1;
+            lblTitle.Text = "Windows 10 Debloat Suite";
             lblTitle.Click += lblTitle_Click;
-            // 
+            //
             // panelStats
-            // 
-            panelStats.BackColor = Color.FromArgb(36, 36, 38);
-            panelStats.BorderStyle = BorderStyle.FixedSingle;
+            //
+            panelStats.BackColor = Color.FromArgb(32, 35, 45);
             panelStats.Controls.Add(lblStats);
-            panelStats.Location = new Point(20, 20);
+            panelStats.Controls.Add(lblStatsTitle);
+            panelStats.Dock = DockStyle.Fill;
+            panelStats.Location = new Point(30, 20);
+            panelStats.Margin = new Padding(0, 0, 20, 20);
             panelStats.Name = "panelStats";
-            panelStats.Size = new Size(220, 220);
+            panelStats.Padding = new Padding(20, 24, 20, 20);
+            panelStats.Size = new Size(310, 280);
             panelStats.TabIndex = 1;
-            // 
+            //
             // lblStats
-            // 
-            lblStats.Font = new Font("Consolas", 9F);
-            lblStats.ForeColor = Color.White;
-            lblStats.Location = new Point(10, 10);
+            //
+            lblStats.Dock = DockStyle.Fill;
+            lblStats.Font = new Font("Consolas", 10F);
+            lblStats.ForeColor = Color.FromArgb(210, 218, 235);
+            lblStats.Location = new Point(20, 54);
+            lblStats.Padding = new Padding(0, 12, 0, 0);
             lblStats.Name = "lblStats";
-            lblStats.Size = new Size(200, 200);
-            lblStats.TabIndex = 0;
+            lblStats.Size = new Size(270, 206);
+            lblStats.TabIndex = 1;
             lblStats.Text = "Loading...";
-            // 
+            //
             // systemInfoTimer
-            // 
+            //
             systemInfoTimer.Interval = 1500;
             systemInfoTimer.Tick += UpdateSystemStats;
-            // 
-            // btnRemoveOneDrive
-            // 
-            btnRemoveOneDrive.Location = new Point(0, 0);
-            btnRemoveOneDrive.Name = "btnRemoveOneDrive";
-            btnRemoveOneDrive.Size = new Size(75, 23);
-            btnRemoveOneDrive.TabIndex = 0;
-            // 
-            // btnRemoveTelemetry
-            // 
-            btnRemoveTelemetry.Location = new Point(0, 0);
-            btnRemoveTelemetry.Name = "btnRemoveTelemetry";
-            btnRemoveTelemetry.Size = new Size(75, 23);
-            btnRemoveTelemetry.TabIndex = 0;
-            // 
-            // btnDisableDefenderCloud
-            // 
-            btnDisableDefenderCloud.Location = new Point(0, 0);
-            btnDisableDefenderCloud.Name = "btnDisableDefenderCloud";
-            btnDisableDefenderCloud.Size = new Size(75, 23);
-            btnDisableDefenderCloud.TabIndex = 0;
-            // 
-            // btnDisableCortana
-            // 
-            btnDisableCortana.Location = new Point(0, 0);
-            btnDisableCortana.Name = "btnDisableCortana";
-            btnDisableCortana.Size = new Size(75, 23);
-            btnDisableCortana.TabIndex = 0;
-            // 
-            // btnDisableAdID
-            // 
-            btnDisableAdID.Location = new Point(0, 0);
-            btnDisableAdID.Name = "btnDisableAdID";
-            btnDisableAdID.Size = new Size(75, 23);
-            btnDisableAdID.TabIndex = 0;
-            // 
-            // btnBlockMicrosoftIPs
-            // 
-            btnBlockMicrosoftIPs.Location = new Point(0, 0);
-            btnBlockMicrosoftIPs.Name = "btnBlockMicrosoftIPs";
-            btnBlockMicrosoftIPs.Size = new Size(75, 23);
-            btnBlockMicrosoftIPs.TabIndex = 0;
-            // 
-            // btnDisableFeedback
-            // 
-            btnDisableFeedback.Location = new Point(0, 0);
-            btnDisableFeedback.Name = "btnDisableFeedback";
-            btnDisableFeedback.Size = new Size(75, 23);
-            btnDisableFeedback.TabIndex = 0;
-            // 
-            // btnRemoveXbox
-            // 
-            btnRemoveXbox.Location = new Point(0, 0);
-            btnRemoveXbox.Name = "btnRemoveXbox";
-            btnRemoveXbox.Size = new Size(75, 23);
-            btnRemoveXbox.TabIndex = 0;
-            // 
-            // btnDisableUpdates
-            // 
-            btnDisableUpdates.Location = new Point(0, 0);
-            btnDisableUpdates.Name = "btnDisableUpdates";
-            btnDisableUpdates.Size = new Size(75, 23);
-            btnDisableUpdates.TabIndex = 0;
-            // 
-            // btnRemoveSuggestions
-            // 
-            btnRemoveSuggestions.Location = new Point(0, 0);
-            btnRemoveSuggestions.Name = "btnRemoveSuggestions";
-            btnRemoveSuggestions.Size = new Size(75, 23);
-            btnRemoveSuggestions.TabIndex = 0;
-            // 
+            //
+            // layoutMain
+            //
+            layoutMain.BackColor = Color.Transparent;
+            layoutMain.ColumnCount = 2;
+            layoutMain.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 38F));
+            layoutMain.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 62F));
+            layoutMain.Controls.Add(panelStats, 0, 0);
+            layoutMain.Controls.Add(panelButtons, 1, 0);
+            layoutMain.Controls.Add(panelLogger, 0, 1);
+            layoutMain.Dock = DockStyle.Fill;
+            layoutMain.Location = new Point(0, 110);
+            layoutMain.Name = "layoutMain";
+            layoutMain.Padding = new Padding(30, 20, 30, 30);
+            layoutMain.RowCount = 2;
+            layoutMain.RowStyles.Add(new RowStyle(SizeType.Percent, 55F));
+            layoutMain.RowStyles.Add(new RowStyle(SizeType.Percent, 45F));
+            layoutMain.Size = new Size(920, 490);
+            layoutMain.TabIndex = 2;
+            layoutMain.SetRowSpan(panelButtons, 2);
+            //
+            // panelButtons
+            //
+            panelButtons.BackColor = Color.FromArgb(32, 35, 45);
+            panelButtons.Controls.Add(flowButtons);
+            panelButtons.Controls.Add(panelRunAll);
+            panelButtons.Controls.Add(lblActionsTitle);
+            panelButtons.Dock = DockStyle.Fill;
+            panelButtons.Location = new Point(360, 20);
+            panelButtons.Margin = new Padding(20, 0, 0, 0);
+            panelButtons.Name = "panelButtons";
+            panelButtons.Padding = new Padding(24, 24, 24, 24);
+            panelButtons.Size = new Size(530, 450);
+            panelButtons.TabIndex = 2;
+            //
+            // flowButtons
+            //
+            flowButtons.AutoScroll = true;
+            flowButtons.BackColor = Color.FromArgb(28, 30, 38);
+            flowButtons.FlowDirection = FlowDirection.LeftToRight;
+            flowButtons.Dock = DockStyle.Fill;
+            flowButtons.Location = new Point(24, 64);
+            flowButtons.Name = "flowButtons";
+            flowButtons.AutoScrollMargin = new Size(0, 16);
+            flowButtons.Padding = new Padding(4, 0, 4, 0);
+            flowButtons.Size = new Size(482, 306);
+            flowButtons.TabIndex = 2;
+            flowButtons.WrapContents = true;
+            //
+            // panelRunAll
+            //
+            panelRunAll.Dock = DockStyle.Bottom;
+            panelRunAll.Location = new Point(24, 370);
+            panelRunAll.Name = "panelRunAll";
+            panelRunAll.Padding = new Padding(0, 18, 0, 18);
+            panelRunAll.Size = new Size(482, 80);
+            panelRunAll.TabIndex = 1;
+            //
+            // lblActionsTitle
+            //
+            lblActionsTitle.AutoSize = false;
+            lblActionsTitle.Dock = DockStyle.Top;
+            lblActionsTitle.Font = new Font("Segoe UI", 11F, FontStyle.Bold);
+            lblActionsTitle.ForeColor = Color.WhiteSmoke;
+            lblActionsTitle.Location = new Point(24, 24);
+            lblActionsTitle.Name = "lblActionsTitle";
+            lblActionsTitle.Size = new Size(482, 40);
+            lblActionsTitle.TabIndex = 0;
+            lblActionsTitle.Text = "Privacy & Debloat Actions";
+            lblActionsTitle.TextAlign = ContentAlignment.MiddleLeft;
+            //
+            // panelLogger
+            //
+            panelLogger.BackColor = Color.FromArgb(32, 35, 45);
+            panelLogger.Controls.Add(lblLoggerTitle);
+            panelLogger.Dock = DockStyle.Fill;
+            panelLogger.Location = new Point(30, 290);
+            panelLogger.Margin = new Padding(0, 0, 20, 0);
+            panelLogger.Name = "panelLogger";
+            panelLogger.Padding = new Padding(20, 24, 20, 20);
+            panelLogger.Size = new Size(310, 180);
+            panelLogger.TabIndex = 3;
+            //
+            // lblLoggerTitle
+            //
+            lblLoggerTitle.AutoSize = false;
+            lblLoggerTitle.Dock = DockStyle.Top;
+            lblLoggerTitle.Font = new Font("Segoe UI", 10F, FontStyle.Bold);
+            lblLoggerTitle.ForeColor = Color.WhiteSmoke;
+            lblLoggerTitle.Location = new Point(20, 24);
+            lblLoggerTitle.Name = "lblLoggerTitle";
+            lblLoggerTitle.Size = new Size(270, 28);
+            lblLoggerTitle.TabIndex = 0;
+            lblLoggerTitle.Text = "Activity Log";
+            lblLoggerTitle.TextAlign = ContentAlignment.MiddleLeft;
+            //
+            // lblStatsTitle
+            //
+            lblStatsTitle.AutoSize = false;
+            lblStatsTitle.Dock = DockStyle.Top;
+            lblStatsTitle.Font = new Font("Segoe UI", 10F, FontStyle.Bold);
+            lblStatsTitle.ForeColor = Color.WhiteSmoke;
+            lblStatsTitle.Location = new Point(20, 24);
+            lblStatsTitle.Name = "lblStatsTitle";
+            lblStatsTitle.Size = new Size(270, 30);
+            lblStatsTitle.TabIndex = 0;
+            lblStatsTitle.Text = "System Snapshot";
+            lblStatsTitle.TextAlign = ContentAlignment.MiddleLeft;
+            //
             // Main
-            // 
+            //
             AutoScaleDimensions = new SizeF(7F, 15F);
             AutoScaleMode = AutoScaleMode.Font;
-            BackColor = Color.FromArgb(28, 28, 30);
-            ClientSize = new Size(850, 520);
-            Controls.Add(lblTitle);
-            Controls.Add(panelStats);
+            BackColor = Color.FromArgb(18, 20, 28);
+            ClientSize = new Size(920, 600);
+            Controls.Add(layoutMain);
+            Controls.Add(panelHeader);
             FormBorderStyle = FormBorderStyle.FixedSingle;
             MaximizeBox = false;
             Name = "Main";
             StartPosition = FormStartPosition.CenterScreen;
-            Text = "Win10 Debloater By Literal";
+            Text = "Windows 10 Debloat Suite";
+            panelHeader.ResumeLayout(false);
+            panelHeader.PerformLayout();
             panelStats.ResumeLayout(false);
+            layoutMain.ResumeLayout(false);
+            panelButtons.ResumeLayout(false);
+            panelLogger.ResumeLayout(false);
             ResumeLayout(false);
-            PerformLayout();
         }
 
         #endregion

--- a/Main.cs
+++ b/Main.cs
@@ -11,17 +11,13 @@ namespace Windows_Debloat_Project
 {
     public partial class Main : Form
     {
-        private readonly int leftX = 260;
-        private readonly int rightX = 540;
-        private readonly int startY = 80;
-        private readonly int spacing = 40;
-
         private Button btnRunAllPrivacy;
         private TextBox txtLogger;
 
         public Main()
         {
             InitializeComponent();
+            DoubleBuffered = true;
             SetupAllButtons();
             SetupLogger();
             Logger.LogBox = txtLogger;
@@ -30,43 +26,72 @@ namespace Windows_Debloat_Project
 
         private void SetupLogger()
         {
-            txtLogger = new TextBox();
-            txtLogger.Multiline = true;
-            txtLogger.ScrollBars = ScrollBars.Vertical;
-            txtLogger.BackColor = Color.Black;
-            txtLogger.ForeColor = Color.Lime;
-            txtLogger.Font = new Font("Consolas", 9F);
-            txtLogger.Location = new Point(20, 360);
-            txtLogger.Size = new Size(800, 120);
-            txtLogger.ReadOnly = true;
-            Controls.Add(txtLogger);
+            txtLogger = new TextBox
+            {
+                Multiline = true,
+                ScrollBars = ScrollBars.Vertical,
+                BackColor = Color.FromArgb(18, 20, 28),
+                ForeColor = Color.FromArgb(210, 218, 235),
+                Font = new Font("Consolas", 9F),
+                ReadOnly = true,
+                BorderStyle = BorderStyle.None,
+                Dock = DockStyle.Fill,
+                Margin = new Padding(0, 12, 0, 0),
+                Text = "Activity log will appear here."
+            };
+
+            panelLogger.Controls.Add(txtLogger);
+            panelLogger.Controls.SetChildIndex(lblLoggerTitle, 0);
+            lblLoggerTitle.BringToFront();
         }
 
         private void SetupAllButtons()
         {
-            // Left Column
-            Controls.Add(new DebloatButton("Remove OneDrive", leftX, startY + spacing * 0, btnRemoveOneDrive_Click));
-            Controls.Add(new DebloatButton("Remove Telemetry", leftX, startY + spacing * 1, btnRemoveTelemetry_Click));
-            Controls.Add(new DebloatButton("Disable Defender Cloud", leftX, startY + spacing * 2, btnDisableDefenderCloud_Click));
-            Controls.Add(new DebloatButton("Disable Cortana", leftX, startY + spacing * 3, btnDisableCortana_Click));
-            Controls.Add(new DebloatButton("Disable Windows Update", leftX, startY + spacing * 4, btnDisableUpdates_Click));
+            flowButtons.SuspendLayout();
 
-            // Right Column
-            Controls.Add(new DebloatButton("Disable Advertising ID", rightX, startY + spacing * 0, btnDisableAdID_Click));
-            Controls.Add(new DebloatButton("Block Microsoft IPs", rightX, startY + spacing * 1, btnBlockMicrosoftIPs_Click));
-            Controls.Add(new DebloatButton("Disable Feedback", rightX, startY + spacing * 2, btnDisableFeedback_Click));
-            Controls.Add(new DebloatButton("Remove Xbox Apps", rightX, startY + spacing * 3, btnRemoveXbox_Click));
-            Controls.Add(new DebloatButton("Remove Suggested Apps", rightX, startY + spacing * 4, btnRemoveSuggestions_Click));
+            AddActionButton("Remove OneDrive", btnRemoveOneDrive_Click);
+            AddActionButton("Remove Telemetry", btnRemoveTelemetry_Click);
+            AddActionButton("Disable Defender Cloud", btnDisableDefenderCloud_Click);
+            AddActionButton("Disable Cortana", btnDisableCortana_Click);
+            AddActionButton("Disable Windows Update", btnDisableUpdates_Click);
+            AddActionButton("Disable Advertising ID", btnDisableAdID_Click);
+            AddActionButton("Block Microsoft IPs", btnBlockMicrosoftIPs_Click);
+            AddActionButton("Disable Feedback", btnDisableFeedback_Click);
+            AddActionButton("Remove Xbox Apps", btnRemoveXbox_Click);
+            AddActionButton("Remove Suggested Apps", btnRemoveSuggestions_Click);
 
-            // Run All Button
-            btnRunAllPrivacy = new DebloatButton("🔥 Run All Privacy Fixes", leftX, startY + spacing * 6, btnRunAllPrivacy_Click)
+            flowButtons.ResumeLayout();
+
+            btnRunAllPrivacy = new Button
             {
-                Width = 540,
-                Height = 40,
-                BackColor = Color.DarkRed,
-                Font = new Font("Segoe UI", 10F, FontStyle.Bold)
+                Text = "Run All Privacy Fixes",
+                Dock = DockStyle.Fill,
+                Height = 48,
+                FlatStyle = FlatStyle.Flat,
+                Font = new Font("Segoe UI", 10F, FontStyle.Bold),
+                BackColor = Color.FromArgb(220, 76, 70),
+                ForeColor = Color.White,
+                Cursor = Cursors.Hand,
+                Margin = new Padding(0)
             };
-            Controls.Add(btnRunAllPrivacy);
+
+            btnRunAllPrivacy.FlatAppearance.BorderSize = 0;
+            btnRunAllPrivacy.FlatAppearance.MouseOverBackColor = Color.FromArgb(232, 99, 92);
+            btnRunAllPrivacy.FlatAppearance.MouseDownBackColor = Color.FromArgb(210, 70, 64);
+            btnRunAllPrivacy.Click += btnRunAllPrivacy_Click;
+
+            panelRunAll.Controls.Add(btnRunAllPrivacy);
+        }
+
+        private void AddActionButton(string text, EventHandler handler)
+        {
+            var button = new DebloatButton(text, handler)
+            {
+                Anchor = AnchorStyles.Top | AnchorStyles.Left,
+                MaximumSize = new Size(220, 44),
+            };
+
+            flowButtons.Controls.Add(button);
         }
 
         private void Confirm(Action action, string message)

--- a/Windows10/Components/GradientPanel.cs
+++ b/Windows10/Components/GradientPanel.cs
@@ -1,0 +1,59 @@
+﻿using System.ComponentModel;
+using System.Drawing;
+using System.Drawing.Drawing2D;
+using System.Windows.Forms;
+
+namespace Windows_Debloat_Project.Windows10.Components
+{
+    public class GradientPanel : Panel
+    {
+        private Color startColor = Color.FromArgb(36, 53, 112);
+        private Color endColor = Color.FromArgb(21, 26, 48);
+        private float angle = 90f;
+
+        [Category("Appearance")]
+        public Color StartColor
+        {
+            get => startColor;
+            set
+            {
+                startColor = value;
+                Invalidate();
+            }
+        }
+
+        [Category("Appearance")]
+        public Color EndColor
+        {
+            get => endColor;
+            set
+            {
+                endColor = value;
+                Invalidate();
+            }
+        }
+
+        [Category("Appearance")]
+        public float Angle
+        {
+            get => angle;
+            set
+            {
+                angle = value;
+                Invalidate();
+            }
+        }
+
+        protected override void OnPaintBackground(PaintEventArgs e)
+        {
+            if (Width == 0 || Height == 0)
+            {
+                base.OnPaintBackground(e);
+                return;
+            }
+
+            using LinearGradientBrush brush = new LinearGradientBrush(ClientRectangle, startColor, endColor, angle);
+            e.Graphics.FillRectangle(brush, ClientRectangle);
+        }
+    }
+}

--- a/Windows10/Wrappers/DebloatButton.cs
+++ b/Windows10/Wrappers/DebloatButton.cs
@@ -6,16 +6,36 @@ namespace Windows_Debloat_Project.Windows10.Wrappers
 {
     public class DebloatButton : Button
     {
+        public DebloatButton(string text, EventHandler handler)
+        {
+            InitializeBase(text, handler);
+        }
+
         public DebloatButton(string text, int x, int y, EventHandler handler)
         {
-            this.Text = text;
-            this.Location = new Point(x, y);
-            this.Size = new Size(260, 32);
-            this.BackColor = Color.FromArgb(45, 45, 48);
-            this.FlatStyle = FlatStyle.Flat;
-            this.Font = new Font("Segoe UI", 9F, FontStyle.Bold);
-            this.ForeColor = Color.White;
-            this.Click += handler;
+            InitializeBase(text, handler);
+            Location = new Point(x, y);
+        }
+
+        private void InitializeBase(string text, EventHandler handler)
+        {
+            Text = text;
+            Size = new Size(220, 44);
+            MinimumSize = new Size(220, 44);
+            BackColor = Color.FromArgb(52, 58, 64);
+            FlatStyle = FlatStyle.Flat;
+            FlatAppearance.BorderSize = 1;
+            FlatAppearance.BorderColor = Color.FromArgb(80, 120, 200);
+            FlatAppearance.MouseOverBackColor = Color.FromArgb(70, 130, 180);
+            FlatAppearance.MouseDownBackColor = Color.FromArgb(60, 110, 160);
+            Font = new Font("Segoe UI", 9F, FontStyle.Bold);
+            ForeColor = Color.WhiteSmoke;
+            Margin = new Padding(8, 8, 8, 12);
+            Padding = new Padding(14, 0, 14, 0);
+            TextAlign = ContentAlignment.MiddleLeft;
+            Cursor = Cursors.Hand;
+            UseVisualStyleBackColor = false;
+            Click += handler;
         }
     }
 }

--- a/Windows10/Wrappers/Logger.cs
+++ b/Windows10/Wrappers/Logger.cs
@@ -10,6 +10,11 @@ namespace Windows_Debloat_Project
         {
             if (LogBox != null)
             {
+                if (LogBox.Text == "Activity log will appear here.")
+                {
+                    LogBox.Clear();
+                }
+
                 LogBox.AppendText(message);
                 LogBox.SelectionStart = LogBox.Text.Length;
                 LogBox.ScrollToCaret();


### PR DESCRIPTION
## Summary
- redesign the main form with a gradient header, split content panels, and improved typography for a more professional feel
- refresh action button styling and layout using a flow layout panel plus an accentuated primary action button
- add a reusable gradient panel helper and tidy the logger placeholder handling for cleaner first-run UX

## Testing
- `dotnet build` *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e0b64b53a883319d48b708c2eb395d